### PR TITLE
Change spaces to tabs for machine readable benchm

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -111,27 +111,27 @@ j_benchmark_run (gchar const* name, BenchmarkFunc benchmark_func)
 	}
 	else
 	{
-		g_print(" %f", result.elapsed_time);
+		g_print("\t%f", result.elapsed_time);
 
 		if (result.operations != 0)
 		{
-			g_print(" %f", (gdouble)result.operations / result.elapsed_time);
+			g_print("\t%f", (gdouble)result.operations / result.elapsed_time);
 		}
 		else
 		{
-			g_print(" -");
+			g_print("\t-");
 		}
 
 		if (result.bytes != 0)
 		{
-			g_print(" %f", (gdouble)result.bytes / result.elapsed_time);
+			g_print("\t%f", (gdouble)result.bytes / result.elapsed_time);
 		}
 		else
 		{
-			g_print(" -");
+			g_print("\t-");
 		}
 
-		g_print(" %f\n", elapsed);
+		g_print("\t%f\n", elapsed);
 	}
 
 	g_timer_destroy(func_timer);


### PR DESCRIPTION
If we use tabs instead of spaces most tools automatically detects
those output as a csv (with tabs) file and thus make it easier to
work with the results.