### PR TITLE
Add missing header include in rados backend

### DIFF
--- a/backend/object/rados.c
+++ b/backend/object/rados.c
@@ -24,6 +24,7 @@
 #include <rados/librados.h>
 
 #include <julea.h>
+#include <julea-internal.h>
 
 /* Initialize cluster and config variables */
 static rados_t backend_connection = NULL;


### PR DESCRIPTION
after a9916cb6466cc7c5de457a95d3cb39d1c61a273d the rados backend won't compile,
because the tracing function header are missing.