### PR TITLE
fixed c++ bindings. switched order of G_BEGIN_DECLS and G_END_DECLS

### DIFF
--- a/include/item/juri.h
+++ b/include/item/juri.h
@@ -63,12 +63,12 @@ struct JURI;
  **/
 typedef struct JURI JURI;
 
-G_BEGIN_DECLS
+G_END_DECLS
 
 #include <item/jcollection.h>
 #include <item/jitem.h>
 
-G_END_DECLS
+G_BEGIN_DECLS
 
 GQuark j_uri_error_quark (void);
 

--- a/include/jmessage.h
+++ b/include/jmessage.h
@@ -65,11 +65,11 @@ struct JMessage;
 
 typedef struct JMessage JMessage;
 
-G_BEGIN_DECLS
+G_END_DECLS
 
 #include <jsemantics.h>
 
-G_END_DECLS
+G_BEGIN_DECLS
 
 JMessage* j_message_new (JMessageType, gsize);
 JMessage* j_message_new_reply (JMessage*);

--- a/include/kv/jkv-uri.h
+++ b/include/kv/jkv-uri.h
@@ -51,11 +51,11 @@ struct JKVURI;
 
 typedef struct JKVURI JKVURI;
 
-G_BEGIN_DECLS
+G_END_DECLS
 
 #include <kv/jkv.h>
 
-G_END_DECLS
+G_BEGIN_DECLS
 
 JKVURI* j_kv_uri_new (gchar const*, JKVURIScheme);
 void j_kv_uri_free (JKVURI*);

--- a/include/object/jobject-uri.h
+++ b/include/object/jobject-uri.h
@@ -55,12 +55,12 @@ struct JObjectURI;
 
 typedef struct JObjectURI JObjectURI;
 
-G_BEGIN_DECLS
+G_END_DECLS
 
 #include <object/jdistributed-object.h>
 #include <object/jobject.h>
 
-G_END_DECLS
+G_BEGIN_DECLS
 
 JObjectURI* j_object_uri_new (gchar const*, JObjectURIScheme);
 void j_object_uri_free (JObjectURI*);


### PR DESCRIPTION
The order of multiple G_BEGIN_DECLS and G_END_DECLS in one header file was like this:

#include <header1.h>
G_BEGIN_DECLS
somestruct;
G_BEGIN_DECLS

#include <header2.h>

G_END_DECLS
somestruct2;
G_END_DECLS

The order is now switched so that every opening declaration is closed before another one is opened.


