### PR TITLE
Fixing write part of Issue #24

### DIFF
--- a/server/server.c
+++ b/server/server.c
@@ -299,21 +299,6 @@ jd_on_run (GThreadedSocketService* service, GSocketConnection* connection, GObje
 						{
 							guint64 bytes_written = 0;
 
-							// Split operation if necessary, write full caches
-							// Consider having an operation with length > J_STRIPE_SIZE
-							while (merge_length > J_STRIPE_SIZE)
-							{
-								g_input_stream_read_all(input, buf, J_STRIPE_SIZE, NULL, NULL, NULL);
-								j_statistics_add(statistics, J_STATISTICS_BYTES_RECEIVED, J_STRIPE_SIZE);
-
-								j_backend_object_write(jd_object_backend, object, buf, J_STRIPE_SIZE, merge_offset, &bytes_written);
-								j_statistics_add(statistics, J_STATISTICS_BYTES_WRITTEN, bytes_written);
-
-								merge_length -= J_STRIPE_SIZE;
-								merge_offset += J_STRIPE_SIZE;
-							}
-
-							// Write the rest
 							g_input_stream_read_all(input, buf, merge_length, NULL, NULL, NULL);
 							j_statistics_add(statistics, J_STATISTICS_BYTES_RECEIVED, merge_length);
 

--- a/server/server.c
+++ b/server/server.c
@@ -219,6 +219,10 @@ jd_on_run (GThreadedSocketService* service, GSocketConnection* connection, GObje
 						length = j_message_get_8(message);
 						offset = j_message_get_8(message);
 
+						// FIXME Easy to create an operation with length > J_STRIPE_SIZE
+						// that will never fit into any memory chunk, reset and use the
+						// full cache of size J_STRIPE_SIZE is no solution
+						// TODO Split such operation
 						buf = j_memory_chunk_get(memory_chunk, length);
 
 						if (buf == NULL)
@@ -287,6 +291,8 @@ jd_on_run (GThreadedSocketService* service, GSocketConnection* connection, GObje
 						offset = j_message_get_8(message);
 
 						/* Check whether we can merge two consecutive operations. */
+						// FIXME Easy to create an operation with length > J_STRIPE_SIZE
+						// TODO Consider split of operations requested too large
 						if (merge_length > 0 && merge_offset + merge_length == offset && merge_length + length <= J_STRIPE_SIZE)
 						{
 							merge_length += length;


### PR DESCRIPTION
This at least fixes write and the crash related with that.
Read does not crash and reports bytes_read = 0 if request was too large.
This now is a stable.