### PR TITLE
Fix wscript to run with no PKG_CONFIG_PATH env

### DIFF
--- a/wscript
+++ b/wscript
@@ -91,7 +91,9 @@ def get_bin (prefixes, bin):
 	return None
 
 def get_pkg_config_path (prefix):
-	env = os.getenv('PKG_CONFIG_PATH').split(':')
+    if os.getenv('PKG_CONFIG_PATH'):
+        env = os.getenv('PKG_CONFIG_PATH').split(':')
+
 	path = []
 
 	# If no prefix has been specified, fall back to the global directories


### PR DESCRIPTION
When waf is used instead of waf.sh to compile against local deps, the script fail as there aren't any strings in 'PKG_CONFIG_PATH' to split. This should fix it.