### PR TITLE
fix random stack errors when using --coverage

### DIFF
--- a/lib/core/jmessage.c
+++ b/lib/core/jmessage.c
@@ -91,7 +91,6 @@ typedef struct JMessageData JMessageData;
 /**
  * A message header.
  **/
-#pragma pack(4)
 struct JMessageHeader
 {
 	/**
@@ -119,7 +118,6 @@ struct JMessageHeader
 	 **/
 	guint32 op_count;
 };
-#pragma pack()
 
 typedef struct JMessageHeader JMessageHeader;
 


### PR DESCRIPTION
When running Julia with code-coverage enabled some random stack errors occur - at very different locations in the code. If the following patch is applied, everything runs fine.

Messages sent over the network are never aligned to anything.