### PR TITLE
transfer the error domain over the network too

### DIFF
--- a/backend/db/sql-generic.c
+++ b/backend/db/sql-generic.c
@@ -217,6 +217,7 @@ freeJSqlCacheSQLPrepared(void* ptr)
 			j_sql_finalize(p->stmt);
 		g_free(p);
 	}
+_error:;
 }
 static JSqlCacheSQLPrepared*
 getCachePrepared(gchar const* namespace, gchar const* name, gchar const* query, GError** error)
@@ -300,6 +301,7 @@ fini_sql(void)
 	j_sql_finalize(stmt_transaction_abort);
 	j_sql_finalize(stmt_transaction_begin);
 	j_sql_finalize(stmt_transaction_commit);
+_error:;
 }
 static gboolean
 backend_batch_start(gchar const* namespace, JSemanticsSafety safety, gpointer* _batch, GError** error)

--- a/backend/db/sqlite.c
+++ b/backend/db/sqlite.c
@@ -315,6 +315,7 @@ backend_fini(void)
 	fini_sql();
 	ret = sqlite3_close(backend_db);
 	j_sql_check(ret, SQLITE_OK);
+_error:;
 }
 static JBackend sqlite_backend = {
 	.type = J_BACKEND_TYPE_DB,

--- a/include/core/jbackend-operation.h
+++ b/include/core/jbackend-operation.h
@@ -61,6 +61,7 @@ struct JBackendOperationParam
 		};
 		struct
 		{
+			const gchar* error_quark_string;
 			GError error;
 			GError* error_ptr;
 		};


### PR DESCRIPTION
this allows using different error domains in the backend code, and transfer them correctly over the network to the client.

Be careful, when using GQuark, because the glib-internal-Integer-ids may be different between server and client.