### PR TITLE
add additional targets to jtrace.

### DIFF
--- a/include/core/jtrace-internal.h
+++ b/include/core/jtrace-internal.h
@@ -51,6 +51,7 @@ struct JTrace;
 typedef struct JTrace JTrace;
 
 void j_trace_init (gchar const*);
+void j_trace_flush (const char*);
 void j_trace_fini (void);
 
 JTrace* j_trace_get_thread_default (void);


### PR DESCRIPTION
 'debug' option verifies that all trace-enter have a matching trace-leave.

'timer' measures the time spend in each function

'sqltimer' formats the output such that it could be used to create an sqltable to search the measured timings.

j_trace_flush can be used to print all measured timings, AND resets all the timers. This could be useful if there are multiple 'equal' stack traces, where the measured times should be separated

removed never used variable from 'struct JTrace'