### PR TITLE
suppress warnings by clang

### DIFF
--- a/include/core/jtrace.h
+++ b/include/core/jtrace.h
@@ -59,11 +59,11 @@ void j_trace_leave (JTrace*);
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(JTrace, j_trace_leave)
 
 #ifdef __COUNTER__
-#define J_TRACE(name, ...) g_autoptr(JTrace) G_PASTE(j_trace, __COUNTER__) G_GNUC_UNUSED = j_trace_enter(name, __VA_ARGS__)
-#define J_TRACE_FUNCTION(...) g_autoptr(JTrace) G_PASTE(j_trace_function, __COUNTER__) G_GNUC_UNUSED = j_trace_enter(G_STRFUNC, __VA_ARGS__)
+#define J_TRACE(name, ...) __attribute__((unused)) g_autoptr(JTrace) G_PASTE(j_trace, __COUNTER__) G_GNUC_UNUSED = j_trace_enter(name, __VA_ARGS__)
+#define J_TRACE_FUNCTION(...) __attribute__((unused)) g_autoptr(JTrace) G_PASTE(j_trace_function, __COUNTER__) G_GNUC_UNUSED = j_trace_enter(G_STRFUNC, __VA_ARGS__)
 #else
-#define J_TRACE(name, ...) g_autoptr(JTrace) G_PASTE(j_trace, __LINE__) G_GNUC_UNUSED = j_trace_enter(name, __VA_ARGS__)
-#define J_TRACE_FUNCTION(...) g_autoptr(JTrace) G_PASTE(j_trace_function, __LINE__) G_GNUC_UNUSED = j_trace_enter(G_STRFUNC, __VA_ARGS__)
+#define J_TRACE(name, ...) __attribute__((unused)) g_autoptr(JTrace) G_PASTE(j_trace, __LINE__) G_GNUC_UNUSED = j_trace_enter(name, __VA_ARGS__)
+#define J_TRACE_FUNCTION(...) __attribute__((unused)) g_autoptr(JTrace) G_PASTE(j_trace_function, __LINE__) G_GNUC_UNUSED = j_trace_enter(G_STRFUNC, __VA_ARGS__)
 #endif
 
 void j_trace_file_begin (gchar const*, JTraceFileOperation);


### PR DESCRIPTION
suppress a lot of set-but-not-used warnings which were emitted by clang and static code analyses