### PR TITLE
unref accepts NULL-parameter - and does nothing if parameter is NULL.…

### DIFF
--- a/backend/object/posix.c
+++ b/backend/object/posix.c
@@ -65,7 +65,7 @@ backend_file_unref (gpointer data)
 
 	G_LOCK(jd_backend_file_cache);
 
-	if (g_atomic_int_dec_and_test(&(file->ref_count)))
+	if (file && g_atomic_int_dec_and_test(&(file->ref_count)))
 	{
 		g_hash_table_remove(jd_backend_file_cache, file->path);
 

--- a/lib/core/jbackground-operation.c
+++ b/lib/core/jbackground-operation.c
@@ -254,9 +254,7 @@ j_background_operation_unref (JBackgroundOperation* background_operation)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(background_operation != NULL);
-
-	if (g_atomic_int_dec_and_test(&(background_operation->ref_count)))
+	if (background_operation && g_atomic_int_dec_and_test(&(background_operation->ref_count)))
 	{
 		g_cond_clear(background_operation->cond);
 		g_mutex_clear(background_operation->mutex);

--- a/lib/core/jbatch.c
+++ b/lib/core/jbatch.c
@@ -189,9 +189,7 @@ j_batch_unref (JBatch* batch)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(batch != NULL);
-
-	if (g_atomic_int_dec_and_test(&(batch->ref_count)))
+	if (batch && g_atomic_int_dec_and_test(&(batch->ref_count)))
 	{
 		if (batch->background_operation != NULL)
 		{

--- a/lib/core/jconfiguration.c
+++ b/lib/core/jconfiguration.c
@@ -395,7 +395,7 @@ j_configuration_unref (JConfiguration* configuration)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	if (g_atomic_int_dec_and_test(&(configuration->ref_count)))
+	if (configuration && g_atomic_int_dec_and_test(&(configuration->ref_count)))
 	{
 		g_free(configuration->db.backend);
 		g_free(configuration->db.component);

--- a/lib/core/jcredentials.c
+++ b/lib/core/jcredentials.c
@@ -82,9 +82,7 @@ j_credentials_unref (JCredentials* credentials)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(credentials != NULL);
-
-	if (g_atomic_int_dec_and_test(&(credentials->ref_count)))
+	if (credentials && g_atomic_int_dec_and_test(&(credentials->ref_count)))
 	{
 		g_slice_free(JCredentials, credentials);
 	}

--- a/lib/core/jdistribution.c
+++ b/lib/core/jdistribution.c
@@ -147,9 +147,7 @@ j_distribution_unref (JDistribution* distribution)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(distribution != NULL);
-
-	if (g_atomic_int_dec_and_test(&(distribution->ref_count)))
+	if (distribution && g_atomic_int_dec_and_test(&(distribution->ref_count)))
 	{
 		j_distribution_vtables[distribution->type].distribution_free(distribution->distribution);
 

--- a/lib/core/jlist.c
+++ b/lib/core/jlist.c
@@ -125,9 +125,7 @@ j_list_unref (JList* list)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(list != NULL);
-
-	if (g_atomic_int_dec_and_test(&(list->ref_count)))
+	if (list && g_atomic_int_dec_and_test(&(list->ref_count)))
 	{
 		j_list_delete_all(list);
 

--- a/lib/core/jmessage.c
+++ b/lib/core/jmessage.c
@@ -417,9 +417,7 @@ j_message_unref (JMessage* message)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(message != NULL);
-
-	if (g_atomic_int_dec_and_test(&(message->ref_count)))
+	if (message && g_atomic_int_dec_and_test(&(message->ref_count)))
 	{
 		if (message->original_message != NULL)
 		{

--- a/lib/core/jsemantics.c
+++ b/lib/core/jsemantics.c
@@ -373,9 +373,7 @@ j_semantics_unref (JSemantics* semantics)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(semantics != NULL);
-
-	if (g_atomic_int_dec_and_test(&(semantics->ref_count)))
+	if (semantics && g_atomic_int_dec_and_test(&(semantics->ref_count)))
 	{
 		g_slice_free(JSemantics, semantics);
 	}

--- a/lib/item/jcollection.c
+++ b/lib/item/jcollection.c
@@ -107,9 +107,7 @@ j_collection_unref (JCollection* collection)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(collection != NULL);
-
-	if (g_atomic_int_dec_and_test(&(collection->ref_count)))
+	if (collection && g_atomic_int_dec_and_test(&(collection->ref_count)))
 	{
 		j_kv_unref(collection->kv);
 		j_credentials_unref(collection->credentials);

--- a/lib/item/jitem.c
+++ b/lib/item/jitem.c
@@ -146,9 +146,7 @@ j_item_unref (JItem* item)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(item != NULL);
-
-	if (g_atomic_int_dec_and_test(&(item->ref_count)))
+	if (item && g_atomic_int_dec_and_test(&(item->ref_count)))
 	{
 		if (item->kv != NULL)
 		{

--- a/lib/kv/jkv.c
+++ b/lib/kv/jkv.c
@@ -570,9 +570,7 @@ j_kv_unref (JKV* kv)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(kv != NULL);
-
-	if (g_atomic_int_dec_and_test(&(kv->ref_count)))
+	if (kv && g_atomic_int_dec_and_test(&(kv->ref_count)))
 	{
 		g_free(kv->key);
 		g_free(kv->namespace);

--- a/lib/object/jdistributed-object.c
+++ b/lib/object/jdistributed-object.c
@@ -482,7 +482,7 @@ j_distributed_object_create_exec (JList* operations, JSemantics* semantics)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	gboolean ret = FALSE;
+	gboolean ret = TRUE;
 
 	JBackend* object_backend;
 	g_autoptr(JListIterator) it = NULL;
@@ -1214,9 +1214,7 @@ j_distributed_object_unref (JDistributedObject* object)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(object != NULL);
-
-	if (g_atomic_int_dec_and_test(&(object->ref_count)))
+	if (object && g_atomic_int_dec_and_test(&(object->ref_count)))
 	{
 		g_free(object->name);
 		g_free(object->namespace);

--- a/lib/object/jobject.c
+++ b/lib/object/jobject.c
@@ -868,9 +868,7 @@ j_object_unref (JObject* object)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	g_return_if_fail(object != NULL);
-
-	if (g_atomic_int_dec_and_test(&(object->ref_count)))
+	if (object && g_atomic_int_dec_and_test(&(object->ref_count)))
 	{
 		g_free(object->name);
 		g_free(object->namespace);


### PR DESCRIPTION
… before sometimes the parameter is asserted to be not NULL, and sometimes it was just expected that the parameter is not NULL - which could cause errors

within glib *_unref is defined as noop if a value is NULL