### PR TITLE
JBackend: stateless object backends

### DIFF
--- a/backend/object/null.c
+++ b/backend/object/null.c
@@ -25,9 +25,11 @@
 
 static
 gboolean
-backend_create (gchar const* namespace, gchar const* path, gpointer* data)
+backend_create (gpointer bData, gchar const* namespace, gchar const* path, gpointer* data)
 {
 	gchar* full_path;
+
+	(void)bData;
 
 	full_path = g_build_filename(namespace, path, NULL);
 
@@ -41,9 +43,11 @@ backend_create (gchar const* namespace, gchar const* path, gpointer* data)
 
 static
 gboolean
-backend_open (gchar const* namespace, gchar const* path, gpointer* data)
+backend_open (gpointer bData, gchar const* namespace, gchar const* path, gpointer* data)
 {
 	gchar* full_path;
+
+	(void)bData;
 
 	full_path = g_build_filename(namespace, path, NULL);
 
@@ -57,9 +61,11 @@ backend_open (gchar const* namespace, gchar const* path, gpointer* data)
 
 static
 gboolean
-backend_delete (gpointer data)
+backend_delete (gpointer bData, gpointer data)
 {
 	gchar* full_path = data;
+
+	(void)bData;
 
 	j_trace_file_begin(full_path, J_TRACE_FILE_DELETE);
 	j_trace_file_end(full_path, J_TRACE_FILE_DELETE, 0, 0);
@@ -71,9 +77,11 @@ backend_delete (gpointer data)
 
 static
 gboolean
-backend_close (gpointer data)
+backend_close (gpointer bData, gpointer data)
 {
 	gchar* full_path = data;
+
+	(void)bData;
 
 	j_trace_file_begin(full_path, J_TRACE_FILE_CLOSE);
 	j_trace_file_end(full_path, J_TRACE_FILE_CLOSE, 0, 0);
@@ -85,9 +93,11 @@ backend_close (gpointer data)
 
 static
 gboolean
-backend_status (gpointer data, gint64* modification_time, guint64* size)
+backend_status (gpointer bData, gpointer data, gint64* modification_time, guint64* size)
 {
 	gchar const* full_path = data;
+
+	(void)bData;
 
 	j_trace_file_begin(full_path, J_TRACE_FILE_STATUS);
 	j_trace_file_end(full_path, J_TRACE_FILE_STATUS, 0, 0);
@@ -107,9 +117,11 @@ backend_status (gpointer data, gint64* modification_time, guint64* size)
 
 static
 gboolean
-backend_sync (gpointer data)
+backend_sync (gpointer bData, gpointer data)
 {
 	gchar const* full_path = data;
+
+	(void)bData;
 
 	j_trace_file_begin(full_path, J_TRACE_FILE_SYNC);
 	j_trace_file_end(full_path, J_TRACE_FILE_SYNC, 0, 0);
@@ -119,10 +131,11 @@ backend_sync (gpointer data)
 
 static
 gboolean
-backend_read (gpointer data, gpointer buffer, guint64 length, guint64 offset, guint64* bytes_read)
+backend_read (gpointer bData, gpointer data, gpointer buffer, guint64 length, guint64 offset, guint64* bytes_read)
 {
 	gchar const* full_path = data;
 
+	(void)bData;
 	(void)buffer;
 
 	j_trace_file_begin(full_path, J_TRACE_FILE_READ);
@@ -138,10 +151,11 @@ backend_read (gpointer data, gpointer buffer, guint64 length, guint64 offset, gu
 
 static
 gboolean
-backend_write (gpointer data, gconstpointer buffer, guint64 length, guint64 offset, guint64* bytes_written)
+backend_write (gpointer bData, gpointer data, gconstpointer buffer, guint64 length, guint64 offset, guint64* bytes_written)
 {
 	gchar const* full_path = data;
 
+	(void)bData;
 	(void)buffer;
 
 	j_trace_file_begin(full_path, J_TRACE_FILE_WRITE);
@@ -157,8 +171,9 @@ backend_write (gpointer data, gconstpointer buffer, guint64 length, guint64 offs
 
 static
 gboolean
-backend_init (gchar const* path)
+backend_init (gpointer* bData, gchar const* path)
 {
+	(void)bData;
 	(void)path;
 
 	return TRUE;
@@ -166,8 +181,9 @@ backend_init (gchar const* path)
 
 static
 void
-backend_fini (void)
+backend_fini (gpointer bData)
 {
+	(void)bData;
 }
 
 static

--- a/backend/object/rados.c
+++ b/backend/object/rados.c
@@ -25,12 +25,19 @@
 
 #include <julea.h>
 
-/* Initialize cluster and config variables */
-static rados_t backend_connection = NULL;
-static rados_ioctx_t backend_io = NULL;
+struct JBackendData
+{
+	/* Initialize cluster and config variables */
+	rados_t backend_connection;
+	rados_ioctx_t backend_io;
 
-static gchar* backend_pool = NULL;
-static gchar* backend_config = NULL;
+	gchar* backend_pool;
+	gchar* backend_config;
+};
+
+typedef struct JBackendData JBackendData;
+
+
 
 struct JBackendFile
 {
@@ -41,14 +48,15 @@ typedef struct JBackendFile JBackendFile;
 
 static
 gboolean
-backend_create (gchar const* namespace, gchar const* path, gpointer* data)
+backend_create (gpointer bData, gchar const* namespace, gchar const* path, gpointer* data)
 {
 	JBackendFile* bf;
+	JBackendData* backendData = bData;
 	gchar* full_path = g_strconcat(namespace, path, NULL);
 	gint ret = 0;
 
 	j_trace_file_begin(full_path, J_TRACE_FILE_CREATE);
-	ret = rados_write_full(backend_io, full_path, "", 0);
+	ret = rados_write_full(backendData->backend_io, full_path, "", 0);
 	j_trace_file_end(full_path, J_TRACE_FILE_CREATE, 0, 0);
 
 	g_return_val_if_fail(ret == 0, FALSE);
@@ -63,11 +71,13 @@ backend_create (gchar const* namespace, gchar const* path, gpointer* data)
 
 static
 gboolean
-backend_open (gchar const* namespace, gchar const* path, gpointer* data)
+backend_open (gpointer bData, gchar const* namespace, gchar const* path, gpointer* data)
 {
 	JBackendFile* bf;
 	gchar* full_path = g_strconcat(namespace, path, NULL);
 	gint ret = 0;
+
+	(void)bData;
 
 	j_trace_file_begin(full_path, J_TRACE_FILE_OPEN);
 	j_trace_file_end(full_path, J_TRACE_FILE_OPEN, 0, 0);
@@ -84,13 +94,14 @@ backend_open (gchar const* namespace, gchar const* path, gpointer* data)
 
 static
 gboolean
-backend_delete (gpointer data)
+backend_delete (gpointer bData, gpointer data)
 {
+	JBackendData* backendData = bData;
 	JBackendFile* bf = data;
 	gint ret = 0;
 
 	j_trace_file_begin(bf->path, J_TRACE_FILE_DELETE);
-	ret = rados_remove(backend_io, bf->path);
+	ret = rados_remove(backendData->backend_io, bf->path);
 	j_trace_file_end(bf->path, J_TRACE_FILE_DELETE, 0, 0);
 
 	g_free(bf->path);
@@ -101,9 +112,11 @@ backend_delete (gpointer data)
 
 static
 gboolean
-backend_close (gpointer data)
+backend_close (gpointer bData, gpointer data)
 {
 	JBackendFile* bf = data;
+
+	(void)bData;
 
 	j_trace_file_begin(bf->path, J_TRACE_FILE_CLOSE);
 	j_trace_file_end(bf->path, J_TRACE_FILE_CLOSE, 0, 0);
@@ -116,8 +129,9 @@ backend_close (gpointer data)
 
 static
 gboolean
-backend_status (gpointer data, gint64* modification_time, guint64* size)
+backend_status (gpointer bData, gpointer data, gint64* modification_time, guint64* size)
 {
+	JBackendData* backendData = bData;
 	JBackendFile* bf = data;
 	gboolean ret = TRUE;
 	gint64 modification_time_ = 0;
@@ -126,7 +140,7 @@ backend_status (gpointer data, gint64* modification_time, guint64* size)
 	if (modification_time != NULL || size != NULL)
 	{
 		j_trace_file_begin(bf->path, J_TRACE_FILE_STATUS);
-		ret = (rados_stat(backend_io, bf->path, &size_, &modification_time_) == 0);
+		ret = (rados_stat(backendData->backend_io, bf->path, &size_, &modification_time_) == 0);
 		j_trace_file_end(bf->path, J_TRACE_FILE_STATUS, 0, 0);
 
 		if (ret && modification_time != NULL)
@@ -146,9 +160,11 @@ backend_status (gpointer data, gint64* modification_time, guint64* size)
 /* Not implemented */
 static
 gboolean
-backend_sync (gpointer data)
+backend_sync (gpointer bData, gpointer data)
 {
 	JBackendFile* bf = data;
+
+	(void)bData;
 
 	j_trace_file_begin(bf->path, J_TRACE_FILE_SYNC);
 	j_trace_file_end(bf->path, J_TRACE_FILE_SYNC, 0, 0);
@@ -158,13 +174,14 @@ backend_sync (gpointer data)
 
 static
 gboolean
-backend_read (gpointer data, gpointer buffer, guint64 length, guint64 offset, guint64* bytes_read)
+backend_read (gpointer bData, gpointer data, gpointer buffer, guint64 length, guint64 offset, guint64* bytes_read)
 {
+	JBackendData* backendData = bData;
 	JBackendFile* bf = data;
 	gint ret = 0;
 
 	j_trace_file_begin(bf->path, J_TRACE_FILE_READ);
-	ret = rados_read(backend_io, bf->path, buffer, length, offset);
+	ret = rados_read(backendData->backend_io, bf->path, buffer, length, offset);
 	j_trace_file_end(bf->path, J_TRACE_FILE_READ, length, offset);
 
 	g_return_val_if_fail(ret >= 0, FALSE);
@@ -179,13 +196,14 @@ backend_read (gpointer data, gpointer buffer, guint64 length, guint64 offset, gu
 
 static
 gboolean
-backend_write (gpointer data, gconstpointer buffer, guint64 length, guint64 offset, guint64* bytes_written)
+backend_write (gpointer bData, gpointer data, gconstpointer buffer, guint64 length, guint64 offset, guint64* bytes_written)
 {
+	JBackendData* backendData = bData;
 	JBackendFile* bf = data;
 	gint ret = 0;
 
 	j_trace_file_begin(bf->path, J_TRACE_FILE_WRITE);
-	ret = rados_write(backend_io, bf->path, buffer, length, offset);
+	ret = rados_write(backendData->backend_io, bf->path, buffer, length, offset);
 	j_trace_file_end(bf->path, J_TRACE_FILE_WRITE, length, offset);
 
 	g_return_val_if_fail(ret == 0, FALSE);
@@ -200,8 +218,9 @@ backend_write (gpointer data, gconstpointer buffer, guint64 length, guint64 offs
 
 static
 gboolean
-backend_init (gchar const* path)
+backend_init (gpointer* bData, gchar const* path)
 {
+	JBackendData* backendData = g_slice_new(JBackendData);
 	g_auto(GStrv) split = NULL;
 
 	g_return_val_if_fail(path != NULL, FALSE);
@@ -209,51 +228,56 @@ backend_init (gchar const* path)
 	/* Path syntax: [config-path]:[pool]
 	   e.g.: /etc/ceph/ceph.conf:data */
 	split = g_strsplit(path, ":", 0);
-	backend_config = g_strdup(split[0]);
-	backend_pool = g_strdup(split[1]);
+	backendData->backend_config = g_strdup(split[0]);
+	backendData->backend_pool = g_strdup(split[1]);
 
-	g_return_val_if_fail(backend_pool != NULL, FALSE);
-	g_return_val_if_fail(backend_config != NULL, FALSE);
+	g_return_val_if_fail(backendData->backend_pool != NULL, FALSE);
+	g_return_val_if_fail(backendData->backend_config != NULL, FALSE);
 
 	/* Create cluster handle */
-	if (rados_create(&backend_connection, NULL) != 0)
+	if (rados_create(&backendData->backend_connection, NULL) != 0)
 	{
 		g_critical("Can not create a RADOS cluster handle.");
 	}
 
 	/* Read config file */
-	if (rados_conf_read_file(backend_connection, backend_config) != 0)
+	if (rados_conf_read_file(backendData->backend_connection, backendData->backend_config) != 0)
 	{
-		g_critical("Can not read RADOS config file %s.", backend_config);
+		g_critical("Can not read RADOS config file %s.", backendData->backend_config);
 	}
 
 	/* Connect to cluster */
-	if (rados_connect(backend_connection) != 0)
+	if (rados_connect(backendData->backend_connection) != 0)
 	{
 		g_critical("Can not connect to RADOS. Cluster online, config up-to-date and keyring correct linked?");
 	}
 
 	/* Initialize IO and select pool */
-	if (rados_ioctx_create(backend_connection, backend_pool, &backend_io) != 0)
+	if (rados_ioctx_create(backendData->backend_connection, backendData->backend_pool, &backendData->backend_io) != 0)
 	{
-		rados_shutdown(backend_connection);
-		g_critical("Can not connect to RADOS pool %s.", backend_pool);
+		rados_shutdown(backendData->backend_connection);
+		g_critical("Can not connect to RADOS pool %s.", backendData->backend_pool);
 	}
+
+	*bData = backendData;
 
 	return TRUE;
 }
 
 static
 void
-backend_fini (void)
+backend_fini (gpointer bData)
 {
+	JBackendData* backendData = bData;
+
 	/* Close connection to cluster */
-	rados_ioctx_destroy(backend_io);
-	rados_shutdown(backend_connection);
+	rados_ioctx_destroy(backendData->backend_io);
+	rados_shutdown(backendData->backend_connection);
 
 	/* Free memory */
-	g_free(backend_config);
-	g_free(backend_pool);
+	g_free(backendData->backend_config);
+	g_free(backendData->backend_pool);
+	g_free(backendData);
 }
 
 static

--- a/include/core/jbackend.h
+++ b/include/core/jbackend.h
@@ -118,29 +118,32 @@ enum JBackendComponent
 
 typedef enum JBackendComponent JBackendComponent;
 
+typedef struct JBackend JBackend;
+
 struct JBackend
 {
 	JBackendType type;
 	JBackendComponent component;
+	gpointer data;
 
 	union
 	{
 		struct
 		{
-			gboolean (*backend_init) (gchar const*);
-			void (*backend_fini) (void);
+			gboolean (*backend_init) (gpointer*, gchar const*);
+			void (*backend_fini) (gpointer);
 
-			gboolean (*backend_create) (gchar const*, gchar const*, gpointer*);
-			gboolean (*backend_open) (gchar const*, gchar const*, gpointer*);
+			gboolean (*backend_create) (gpointer, gchar const*, gchar const*, gpointer*);
+			gboolean (*backend_open) (gpointer, gchar const*, gchar const*, gpointer*);
 
-			gboolean (*backend_delete) (gpointer);
-			gboolean (*backend_close) (gpointer);
+			gboolean (*backend_delete) (gpointer, gpointer);
+			gboolean (*backend_close) (gpointer, gpointer);
 
-			gboolean (*backend_status) (gpointer, gint64*, guint64*);
-			gboolean (*backend_sync) (gpointer);
+			gboolean (*backend_status) (gpointer, gpointer, gint64*, guint64*);
+			gboolean (*backend_sync) (gpointer, gpointer);
 
-			gboolean (*backend_read) (gpointer, gpointer, guint64, guint64, guint64*);
-			gboolean (*backend_write) (gpointer, gconstpointer, guint64, guint64, guint64*);
+			gboolean (*backend_read) (gpointer, gpointer, gpointer, guint64, guint64, guint64*);
+			gboolean (*backend_write) (gpointer, gpointer, gconstpointer, guint64, guint64, guint64*);
 		}
 		object;
 
@@ -369,8 +372,6 @@ struct JBackend
 	};
 };
 
-typedef struct JBackend JBackend;
-
 GQuark j_backend_bson_error_quark(void);
 GQuark j_backend_db_error_quark (void);
 GQuark j_backend_sql_error_quark (void);
@@ -380,7 +381,7 @@ JBackend* backend_info (void);
 gboolean j_backend_load_client (gchar const*, gchar const*, JBackendType, GModule**, JBackend**);
 gboolean j_backend_load_server (gchar const*, gchar const*, JBackendType, GModule**, JBackend**);
 
-gboolean j_backend_object_init (JBackend*, gchar const*);
+gboolean j_backend_object_init (JBackend**, gchar const*);
 void j_backend_object_fini (JBackend*);
 
 gboolean j_backend_object_create (JBackend*, gchar const*, gchar const*, gpointer*);

--- a/lib/core/jcommon.c
+++ b/lib/core/jcommon.c
@@ -176,7 +176,7 @@ j_init (void)
 
 	if (j_backend_load_client(object_backend, object_component, J_BACKEND_TYPE_OBJECT, &(common->object_module), &(common->object_backend)))
 	{
-		if (common->object_backend == NULL || !j_backend_object_init(common->object_backend, object_path))
+		if (common->object_backend == NULL || !j_backend_object_init(&common->object_backend, object_path))
 		{
 			g_critical("Could not initialize object backend %s.\n", object_backend);
 			goto error;

--- a/server/server.c
+++ b/server/server.c
@@ -248,7 +248,7 @@ main (int argc, char** argv)
 
 	if (j_backend_load_server(object_backend, object_component, J_BACKEND_TYPE_OBJECT, &object_module, &jd_object_backend))
 	{
-		if (jd_object_backend == NULL || !j_backend_object_init(jd_object_backend, object_path))
+		if (jd_object_backend == NULL || !j_backend_object_init(&jd_object_backend, object_path))
 		{
 			g_critical("Could not initialize object backend %s.\n", object_backend);
 			return 1;


### PR DESCRIPTION
This commit makes the object backens stateless. Previously they all
store there data from initialization, mainly a path, in a global
variable. This made it impossible to load and initialization the same
backend twice with different parameters. E.g. two posix backends one on
a SSD and another one on a HDD.

Changes:
jbackend.h:
The JBackend struct were extended by a gpointer called data
to hold arbitrary data specified by each backend.
The signature of the backend functions are extended by a gpointer to
this new data field. The init function is given the address of the new
data field for initialization.

jbackend.c:
The JBackend returned by j_backend_load is a pointer to a
static variabel in the backend and therefore always the same and not
suitable to hold differently initialized instances of a backend. To
overcome this j_object_init know allocates a new JBackend and copys the
data from the JBackend loaded via j_backend_load. On initialization the
backen can then store its data in the new data field of this JBackend.
The new JBackend is free in j_backend_fini.

server.c and jcommon.c:
They both  need to pass the address of JBackend pointer to
j_backend_init now, as j_object_init replaces the data withe the new
initialized one.

Backends:
In all backends the global variable where move to a new JBackendData
struct which is initialized in the init function and free in fini.

posix.c:
Here only the path were move to the JBackendData struct as the other
global variables holding hash tables for caching can not be moved to a
struct easily without altering the previous behavior. This means all
loaded backend are sharing caches, the global one as well as thread
local cache.

This functionality is need for a future HSM implementation.