### PR TITLE
add reset function to db backend

### DIFF
--- a/backend/db/sqlite.c
+++ b/backend/db/sqlite.c
@@ -38,7 +38,9 @@
 #define SQL_MODE_MULTI_THREAD 1
 #define SQL_MODE SQL_MODE_SINGLE_THREAD
 
-#define sql_autoincrement_string ""
+#define sql_autoincrement_string " "
+#define sql_last_insert_id_string " SELECT last_insert_rowid() "
+#define sql_get_table_names "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '%s_%%'"
 
 static gchar* path;
 
@@ -59,7 +61,8 @@ _error:
 	return FALSE;
 }
 
-static gboolean
+static
+gboolean
 j_sql_prepare(sqlite3* backend_db, const char* sql, void* _stmt, GArray* types_in, GArray* types_out, GError** error)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -68,11 +71,9 @@ j_sql_prepare(sqlite3* backend_db, const char* sql, void* _stmt, GArray* types_i
 	(void)types_in;
 	(void)types_out;
 
-	//g_debug("sql = %s", sql);
-
 	if (G_UNLIKELY(sqlite3_prepare_v3(backend_db, sql, -1, SQLITE_PREPARE_PERSISTENT, stmt, NULL) != SQLITE_OK))
 	{
-		g_set_error(error, J_BACKEND_SQL_ERROR, J_BACKEND_SQL_ERROR_PREPARE, "sql prepare failed error was '%s'", sqlite3_errmsg(backend_db));
+		g_set_error(error, J_BACKEND_SQL_ERROR, J_BACKEND_SQL_ERROR_PREPARE, "sql prepare failed error was <%s> '%s'", sql, sqlite3_errmsg(backend_db));
 		goto _error;
 	}
 	return TRUE;
@@ -81,7 +82,8 @@ _error:
 	return FALSE;
 }
 
-static gboolean
+static
+gboolean
 j_sql_bind_null(sqlite3* backend_db, void* _stmt, guint idx, GError** error)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -98,7 +100,8 @@ _error:
 	return FALSE;
 }
 
-static gboolean
+static
+gboolean
 j_sql_column(sqlite3* backend_db, void* _stmt, guint idx, JDBType type, JDBTypeValue* value, GError** error)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -145,11 +148,11 @@ _error:
 	return FALSE;
 }
 
-static gboolean
+static
+gboolean
 j_sql_bind_value(sqlite3* backend_db, void* _stmt, guint idx, JDBType type, JDBTypeValue* value, GError** error)
 {
 	J_TRACE_FUNCTION(NULL);
-
 	sqlite3_stmt* stmt = _stmt;
 
 	switch (type)
@@ -220,11 +223,11 @@ j_sql_bind_value(sqlite3* backend_db, void* _stmt, guint idx, JDBType type, JDBT
 _error:
 	return FALSE;
 }
-static gboolean
+static
+gboolean
 j_sql_reset(sqlite3* backend_db, void* _stmt, GError** error)
 {
 	J_TRACE_FUNCTION(NULL);
-
 	sqlite3_stmt* stmt = _stmt;
 
 	if (G_UNLIKELY(sqlite3_reset(stmt) != SQLITE_OK))
@@ -237,25 +240,52 @@ _error:
 	return FALSE;
 }
 
-static gboolean
-j_sql_exec(sqlite3* backend_db, const char* sql, GError** error)
+static
+gboolean
+j_sql_step(sqlite3* backend_db, void* _stmt, gboolean* found, GError** error)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	sqlite3_stmt* stmt;
-
-	if (G_UNLIKELY(!j_sql_prepare(backend_db, sql, &stmt, NULL, NULL, error)))
+	sqlite3_stmt* stmt = _stmt;
+	guint ret;
+	ret = sqlite3_step(stmt);
+	*found = ret == SQLITE_ROW;
+	if (ret != SQLITE_ROW)
 	{
+		if (G_UNLIKELY(ret == SQLITE_CONSTRAINT))
+		{
+			g_set_error(error, J_BACKEND_SQL_ERROR, J_BACKEND_SQL_ERROR_CONSTRAINT, "sql constraint failed error was '%s'", sqlite3_errmsg(backend_db));
 		goto _error;
 	}
-	if (G_UNLIKELY(sqlite3_step(stmt) != SQLITE_DONE))
+		else if (G_UNLIKELY(ret != SQLITE_DONE))
 	{
 		g_set_error(error, J_BACKEND_SQL_ERROR, J_BACKEND_SQL_ERROR_STEP, "sql step failed error was '%s'", sqlite3_errmsg(backend_db));
 		goto _error;
 	}
+	}
+	return TRUE;
+_error:
+	return FALSE;
+}
+static
+gboolean
+j_sql_exec(sqlite3* backend_db, const char* sql, GError** error)
+{
+	J_TRACE_FUNCTION(NULL);
+	sqlite3_stmt* stmt;
+	gboolean found;
+
+	if (G_UNLIKELY(!j_sql_prepare(backend_db, sql, &stmt, NULL, NULL, error)))
+		{
+		goto _error2;
+		}
+	if (G_UNLIKELY(!j_sql_step(backend_db, stmt, &found, error)))
+		{
+			goto _error;
+		}
 	if (G_UNLIKELY(!j_sql_finalize(backend_db, stmt, error)))
 	{
-		goto _error;
+		goto _error2;
 	}
 	return TRUE;
 _error:
@@ -268,38 +298,11 @@ _error2:
 	/*something failed very hard*/
 	return FALSE;
 }
-static gboolean
-j_sql_step(sqlite3* backend_db, void* _stmt, gboolean* found, GError** error)
-{
-	J_TRACE_FUNCTION(NULL);
-
-	sqlite3_stmt* stmt = _stmt;
-	guint ret;
-
-	ret = sqlite3_step(stmt);
-	*found = ret == SQLITE_ROW;
-	if (ret != SQLITE_ROW)
-	{
-		if (G_UNLIKELY(ret == SQLITE_CONSTRAINT))
-		{
-			g_set_error(error, J_BACKEND_SQL_ERROR, J_BACKEND_SQL_ERROR_CONSTRAINT, "sql constraint failed error was '%s'", sqlite3_errmsg(backend_db));
-			goto _error;
-		}
-		else if (G_UNLIKELY(ret != SQLITE_DONE))
-		{
-			g_set_error(error, J_BACKEND_SQL_ERROR, J_BACKEND_SQL_ERROR_STEP, "sql step failed error was '%s'", sqlite3_errmsg(backend_db));
-			goto _error;
-		}
-	}
-	return TRUE;
-_error:
-	return FALSE;
-}
-static gboolean
+static
+gboolean
 j_sql_step_and_reset_check_done(sqlite3* backend_db, void* _stmt, GError** error)
 {
 	J_TRACE_FUNCTION(NULL);
-
 	gboolean sql_found;
 
 	if (G_UNLIKELY(!j_sql_step(backend_db, _stmt, &sql_found, error)))
@@ -321,7 +324,8 @@ _error2:
 	/*something failed very hard*/
 	return FALSE;
 }
-static void*
+static
+void*
 j_sql_open(void)
 {
 	J_TRACE_FUNCTION(NULL);
@@ -351,57 +355,69 @@ j_sql_open(void)
 	{
 		goto _error;
 	}
+
 	return backend_db;
 _error:
 	sqlite3_close(backend_db);
 	return NULL;
 }
-static void
+static
+void
 j_sql_close(sqlite3* backend_db)
 {
 	J_TRACE_FUNCTION(NULL);
 
+
 	sqlite3_close(backend_db);
 }
-static gboolean
+static
+gboolean
 j_sql_start_transaction(sqlite3* backend_db, GError** error)
 {
+	J_TRACE_FUNCTION(NULL);
+
 	return j_sql_exec(backend_db, "BEGIN TRANSACTION", error);
 }
-static gboolean
+static
+gboolean
 j_sql_commit_transaction(sqlite3* backend_db, GError** error)
 {
+	J_TRACE_FUNCTION(NULL);
+
 	return j_sql_exec(backend_db, "COMMIT", error);
 }
-static gboolean
+static
+gboolean
 j_sql_abort_transaction(sqlite3* backend_db, GError** error)
 {
+	J_TRACE_FUNCTION(NULL);
+
 	return j_sql_exec(backend_db, "ROLLBACK", error);
 }
 #include "sql-generic.c"
-static gboolean
+static
+gboolean
 backend_init(gchar const* _path)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	//g_debug("db-backend-init %s", _path);
 
 	path = g_strdup(_path);
 	return TRUE;
 }
-static void
+static
+void
 backend_fini(void)
 {
 	J_TRACE_FUNCTION(NULL);
 
-	//g_debug("db-backend-fini");
-
-	g_private_replace(&thread_variables_global, NULL);
 	g_free(path);
 }
-static JBackend sqlite_backend = {
+static
+JBackend sqlite_backend = {
 	.type = J_BACKEND_TYPE_DB,
-	.component = J_BACKEND_COMPONENT_SERVER,
+	.component = J_BACKEND_COMPONENT_SERVER | J_BACKEND_COMPONENT_CLIENT,
+	.backend_reset = backend_reset,
 	.db = {
 		.backend_init = backend_init,
 		.backend_fini = backend_fini,
@@ -422,5 +438,7 @@ G_MODULE_EXPORT
 JBackend*
 backend_info(void)
 {
+	J_TRACE_FUNCTION(NULL);
+
 	return &sqlite_backend;
 }

--- a/include/core/jbackend-operation.h
+++ b/include/core/jbackend-operation.h
@@ -108,9 +108,28 @@ gboolean j_backend_operation_unwrap_db_update (JBackend*, gpointer, JBackendOper
 gboolean j_backend_operation_unwrap_db_delete (JBackend*, gpointer, JBackendOperation*);
 gboolean j_backend_operation_unwrap_db_query (JBackend*, gpointer, JBackendOperation*);
 
+gboolean j_backend_operation_unwrap_reset(JBackend* backend,gpointer,JBackendOperation*);
+
 gboolean j_backend_operation_to_message (JMessage* message, JBackendOperationParam* data, guint len);
 gboolean j_backend_operation_from_message (JMessage* message, JBackendOperationParam* data, guint len);
 gboolean j_backend_operation_from_message_static (JMessage* message, JBackendOperationParam* data, guint len);
+
+static const JBackendOperation j_backend_operation_reset = {
+	.backend_func = j_backend_operation_unwrap_reset,
+	.in_param_count = 1,
+	.out_param_count = 1,
+	.in_param = {
+		{
+			.type = J_BACKEND_OPERATION_PARAM_TYPE_STR,
+		},
+	},
+	.out_param = {
+		{
+			.type = J_BACKEND_OPERATION_PARAM_TYPE_ERROR,
+		},
+	},
+};
+
 
 static const JBackendOperation j_backend_operation_db_schema_create = {
 	.backend_func = j_backend_operation_unwrap_db_schema_create,

--- a/include/core/jbackend.h
+++ b/include/core/jbackend.h
@@ -126,6 +126,13 @@ struct JBackend
 	JBackendType type;
 	JBackendComponent component;
 
+	/**
+	 * delete everything in the backend
+	 * \param[in] which namespace to delete
+	 * \param[out] how many "things" are deleted within the specified namespace
+	 */
+	gboolean (*backend_reset)(gpointer, GError**);
+
 	union
 	{
 		struct
@@ -429,6 +436,7 @@ gboolean j_backend_db_delete (JBackend*, gpointer, gchar const*, bson_t const*, 
 gboolean j_backend_db_query (JBackend*, gpointer, gchar const*, bson_t const*, gpointer*, GError**);
 gboolean j_backend_db_iterate (JBackend*, gpointer, bson_t*, GError**);
 
+gboolean j_backend_reset (JBackend* backend, gpointer, GError**);
 G_END_DECLS
 
 #endif

--- a/include/core/jmessage.h
+++ b/include/core/jmessage.h
@@ -53,7 +53,8 @@ enum JMessageType
 	J_MESSAGE_DB_INSERT,
 	J_MESSAGE_DB_UPDATE,
 	J_MESSAGE_DB_DELETE,
-	J_MESSAGE_DB_QUERY
+	J_MESSAGE_DB_QUERY,
+	J_MESSAGE_RESET
 };
 
 typedef enum JMessageType JMessageType;

--- a/include/db/jdb-internal.h
+++ b/include/db/jdb-internal.h
@@ -113,6 +113,8 @@ gboolean j_db_internal_delete (gchar const* namespace, gchar const* name, bson_t
 gboolean j_db_internal_query (gchar const* namespace, gchar const* name, bson_t const* selector, gpointer* iterator, JBatch* batch, GError** error);
 gboolean j_db_internal_iterate (gpointer iterator, bson_t* metadata, GError** error);
 
+gboolean j_internal_reset (gchar const* namespace, JBatch* batch, GError** error);
+
 // Client-side additional internal functions
 bson_t* j_db_selector_get_bson (JDBSelector* selector);
 

--- a/lib/core/jbackend-operation.c
+++ b/lib/core/jbackend-operation.c
@@ -39,6 +39,14 @@
  **/
 
 gboolean
+j_backend_operation_unwrap_reset(JBackend* backend, gpointer batch, JBackendOperation* data)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	return j_backend_reset(backend, batch, data->out_param[0].ptr);
+}
+
+gboolean
 j_backend_operation_unwrap_db_schema_create (JBackend* backend, gpointer batch, JBackendOperation* data)
 {
 	J_TRACE_FUNCTION(NULL);

--- a/lib/core/jbackend.c
+++ b/lib/core/jbackend.c
@@ -896,6 +896,22 @@ j_backend_db_iterate (JBackend* backend, gpointer iterator, bson_t* metadata, GE
 	return ret;
 }
 
+gboolean
+j_backend_reset(JBackend* backend, gpointer batch, GError** error)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	g_return_val_if_fail(backend != NULL, FALSE);
+	g_return_val_if_fail(batch != NULL, FALSE);
+	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
+
+	if (backend->backend_reset)
+	{
+		return backend->backend_reset(batch, error);
+	}
+	return TRUE;
+}
+
 /**
  * @}
  **/

--- a/lib/db/jdb-internal.c
+++ b/lib/db/jdb-internal.c
@@ -155,6 +155,36 @@ j_backend_db_func_free (gpointer _data)
 
 static
 gboolean
+j_reset_exec (JList* operations, JSemantics* semantics)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	//FIXME call this on EVERY backend(type)
+	return j_backend_db_func_exec(operations, semantics, J_MESSAGE_RESET);
+}
+gboolean
+j_internal_reset (gchar const* namespace, JBatch* batch, GError** error)
+{
+	J_TRACE_FUNCTION(NULL);
+
+	JOperation* op;
+	JBackendOperation* data;
+
+	data = g_slice_new(JBackendOperation);
+	memcpy(data, &j_backend_operation_reset, sizeof(JBackendOperation));
+	data->in_param[0].ptr_const = namespace;
+	data->out_param[0].ptr_const = error;
+	op = j_operation_new();
+	op->key = namespace;
+	op->data = data;
+	op->exec_func = j_reset_exec;
+	op->free_func = j_backend_db_func_free;
+	j_batch_add(batch, op);
+	return TRUE;
+}
+
+static
+gboolean
 j_db_schema_create_exec (JList* operations, JSemantics* semantics)
 {
 	J_TRACE_FUNCTION(NULL);

--- a/server/loop.c
+++ b/server/loop.c
@@ -553,6 +553,13 @@ jd_handle_message (JMessage* message, GSocketConnection* connection, JMemoryChun
 				j_message_send(reply, connection);
 			}
 			break;
+	case J_MESSAGE_RESET:
+		if (!message_matched)
+		{
+			memcpy(&backend_operation, &j_backend_operation_reset, sizeof(JBackendOperation));
+			message_matched = TRUE;
+		}
+		// fallthrough
 		case J_MESSAGE_DB_SCHEMA_CREATE:
 			if (!message_matched)
 			{


### PR DESCRIPTION
the reset function counts all entries in all tables, and then deletes every table within the specified namespace.
this is for unit tests which require a clean backend.
after the test this function can be used to verify, that there are only empty schemata