### PR TITLE
Pull fix refcounting

### DIFF
--- a/include/core/jbackend-operation.h
+++ b/include/core/jbackend-operation.h
@@ -89,6 +89,10 @@ struct JBackendOperation
 	// Output parameters
 	// The last out parameter must be of type 'J_BACKEND_OPERATION_PARAM_TYPE_ERROR'
 	JBackendOperationParam out_param[20];
+	//refcounting objects which are required for transmission - unref those after use
+	guint unref_func_count;
+	void (*unref_funcs[20])(gpointer value);
+	gpointer unref_values[20];
 };
 
 typedef struct JBackendOperation JBackendOperation;
@@ -130,7 +134,8 @@ static const JBackendOperation j_backend_operation_db_schema_create = {
 	},
 };
 
-static const JBackendOperation j_backend_operation_db_schema_get = {
+static
+const JBackendOperation j_backend_operation_db_schema_get = {
 	.backend_func = j_backend_operation_unwrap_db_schema_get,
 	.in_param_count = 2,
 	.out_param_count = 2,
@@ -147,7 +152,8 @@ static const JBackendOperation j_backend_operation_db_schema_get = {
 	},
 };
 
-static const JBackendOperation j_backend_operation_db_schema_delete = {
+static
+const JBackendOperation j_backend_operation_db_schema_delete = {
 	.backend_func = j_backend_operation_unwrap_db_schema_delete,
 	.in_param_count = 2,
 	.out_param_count = 1,
@@ -160,7 +166,8 @@ static const JBackendOperation j_backend_operation_db_schema_delete = {
 	},
 };
 
-static const JBackendOperation j_backend_operation_db_insert = {
+static
+const JBackendOperation j_backend_operation_db_insert = {
 	.backend_func = j_backend_operation_unwrap_db_insert,
 	.in_param_count = 3,
 	.out_param_count = 2,
@@ -181,7 +188,8 @@ static const JBackendOperation j_backend_operation_db_insert = {
 	},
 };
 
-static const JBackendOperation j_backend_operation_db_update = {
+static
+const JBackendOperation j_backend_operation_db_update = {
 	.backend_func = j_backend_operation_unwrap_db_update,
 	.in_param_count = 4,
 	.out_param_count = 1,
@@ -202,7 +210,8 @@ static const JBackendOperation j_backend_operation_db_update = {
 	},
 };
 
-static const JBackendOperation j_backend_operation_db_delete = {
+static
+const JBackendOperation j_backend_operation_db_delete = {
 	.backend_func = j_backend_operation_unwrap_db_delete,
 	.in_param_count = 3,
 	.out_param_count = 1,
@@ -219,7 +228,8 @@ static const JBackendOperation j_backend_operation_db_delete = {
 	},
 };
 
-static const JBackendOperation j_backend_operation_db_query = {
+static
+const JBackendOperation j_backend_operation_db_query = {
 	.backend_func = j_backend_operation_unwrap_db_query,
 	.in_param_count = 3,
 	.out_param_count = 2,

--- a/include/core/jbackend-operation.h
+++ b/include/core/jbackend-operation.h
@@ -134,8 +134,7 @@ static const JBackendOperation j_backend_operation_db_schema_create = {
 	},
 };
 
-static
-const JBackendOperation j_backend_operation_db_schema_get = {
+static const JBackendOperation j_backend_operation_db_schema_get = {
 	.backend_func = j_backend_operation_unwrap_db_schema_get,
 	.in_param_count = 2,
 	.out_param_count = 2,
@@ -152,8 +151,7 @@ const JBackendOperation j_backend_operation_db_schema_get = {
 	},
 };
 
-static
-const JBackendOperation j_backend_operation_db_schema_delete = {
+static const JBackendOperation j_backend_operation_db_schema_delete = {
 	.backend_func = j_backend_operation_unwrap_db_schema_delete,
 	.in_param_count = 2,
 	.out_param_count = 1,
@@ -166,8 +164,7 @@ const JBackendOperation j_backend_operation_db_schema_delete = {
 	},
 };
 
-static
-const JBackendOperation j_backend_operation_db_insert = {
+static const JBackendOperation j_backend_operation_db_insert = {
 	.backend_func = j_backend_operation_unwrap_db_insert,
 	.in_param_count = 3,
 	.out_param_count = 2,
@@ -188,8 +185,7 @@ const JBackendOperation j_backend_operation_db_insert = {
 	},
 };
 
-static
-const JBackendOperation j_backend_operation_db_update = {
+static const JBackendOperation j_backend_operation_db_update = {
 	.backend_func = j_backend_operation_unwrap_db_update,
 	.in_param_count = 4,
 	.out_param_count = 1,
@@ -210,8 +206,7 @@ const JBackendOperation j_backend_operation_db_update = {
 	},
 };
 
-static
-const JBackendOperation j_backend_operation_db_delete = {
+static const JBackendOperation j_backend_operation_db_delete = {
 	.backend_func = j_backend_operation_unwrap_db_delete,
 	.in_param_count = 3,
 	.out_param_count = 1,
@@ -228,8 +223,7 @@ const JBackendOperation j_backend_operation_db_delete = {
 	},
 };
 
-static
-const JBackendOperation j_backend_operation_db_query = {
+static const JBackendOperation j_backend_operation_db_query = {
 	.backend_func = j_backend_operation_unwrap_db_query,
 	.in_param_count = 3,
 	.out_param_count = 2,

--- a/include/db/jdb-internal.h
+++ b/include/db/jdb-internal.h
@@ -33,8 +33,7 @@
 
 #include <julea.h>
 
-#include <db/jdb-schema.h>
-#include <db/jdb-selector.h>
+#include <julea-db.h>
 
 G_BEGIN_DECLS
 
@@ -105,14 +104,14 @@ union JDBTypeValue
 };
 
 // Client-side wrappers for backend functions
-gboolean j_db_internal_schema_create (gchar const* namespace, gchar const* name, bson_t const* schema, JBatch* batch, GError** error);
-gboolean j_db_internal_schema_get (gchar const* namespace, gchar const* name, bson_t* schema, JBatch* batch, GError** error);
-gboolean j_db_internal_schema_delete (gchar const* namespace, gchar const* name, JBatch* batch, GError** error);
-gboolean j_db_internal_insert (gchar const* namespace, gchar const* name, bson_t const* metadata, bson_t* id, JBatch* batch, GError** error);
-gboolean j_db_internal_update (gchar const* namespace, gchar const* name, bson_t const* selector, bson_t const* metadata, JBatch* batch, GError** error);
-gboolean j_db_internal_delete (gchar const* namespace, gchar const* name, bson_t const* selector, JBatch* batch, GError** error);
-gboolean j_db_internal_query (gchar const* namespace, gchar const* name, bson_t const* selector, gpointer* iterator, JBatch* batch, GError** error);
-gboolean j_db_internal_iterate (gpointer iterator, bson_t* metadata, GError** error);
+gboolean j_db_internal_schema_create(JDBSchema* j_db_schema, JBatch* batch, GError** error);
+gboolean j_db_internal_schema_get(JDBSchema* j_db_schema, JBatch* batch, GError** error);
+gboolean j_db_internal_schema_delete(JDBSchema* j_db_schema, JBatch* batch, GError** error);
+gboolean j_db_internal_insert(JDBEntry* j_db_entry, JBatch* batch, GError** error);
+gboolean j_db_internal_update(JDBEntry* j_db_entry, JDBSelector* j_db_selector, JBatch* batch, GError** error);
+gboolean j_db_internal_delete(JDBEntry* j_db_entry, JDBSelector* j_db_selector, JBatch* batch, GError** error);
+gboolean j_db_internal_query(JDBSchema* j_db_schema, JDBSelector* j_db_selector, JDBIterator* j_db_iterator, JBatch* batch, GError** error);
+gboolean j_db_internal_iterate(JDBIterator* j_db_iterator, GError** error);
 
 // Client-side additional internal functions
 bson_t* j_db_selector_get_bson (JDBSelector* selector);

--- a/lib/db/jdb-entry.c
+++ b/lib/db/jdb-entry.c
@@ -180,7 +180,7 @@ j_db_entry_insert (JDBEntry* entry, JBatch* batch, GError** error)
 	g_return_val_if_fail(batch != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (G_UNLIKELY(!j_db_internal_insert(entry->schema->namespace, entry->schema->name, &entry->bson, &entry->id, batch, error)))
+	if (G_UNLIKELY(!j_db_internal_insert(entry, batch, error)))
 	{
 		goto _error;
 	}
@@ -212,7 +212,7 @@ j_db_entry_update (JDBEntry* entry, JDBSelector* selector, JBatch* batch, GError
 		goto _error;
 	}
 
-	if (G_UNLIKELY(!j_db_internal_update(entry->schema->namespace, entry->schema->name, bson, &entry->bson, batch, error)))
+	if (G_UNLIKELY(!j_db_internal_update(entry, selector, batch, error)))
 	{
 		goto _error;
 	}
@@ -233,7 +233,7 @@ j_db_entry_delete (JDBEntry* entry, JDBSelector* selector, JBatch* batch, GError
 	g_return_val_if_fail((selector == NULL) || (selector->schema == entry->schema), FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (G_UNLIKELY(!j_db_internal_delete(entry->schema->namespace, entry->schema->name, j_db_selector_get_bson(selector), batch, error)))
+	if (G_UNLIKELY(!j_db_internal_delete(entry, selector, batch, error)))
 	{
 		goto _error;
 	}

--- a/lib/db/jdb-iterator.c
+++ b/lib/db/jdb-iterator.c
@@ -74,7 +74,7 @@ j_db_iterator_new (JDBSchema* schema, JDBSelector* selector, GError** error)
 	iterator->valid = FALSE;
 	iterator->bson_valid = FALSE;
 	batch = j_batch_new_for_template(J_SEMANTICS_TEMPLATE_DEFAULT);
-	ret2 = j_db_internal_query(schema->namespace, schema->name, j_db_selector_get_bson(selector), &iterator->iterator, batch, error);
+	ret2 = j_db_internal_query(schema, selector, iterator, batch, error);
 	ret = ret2 && j_batch_execute(batch);
 	j_batch_unref(batch);
 
@@ -90,7 +90,7 @@ j_db_iterator_new (JDBSchema* schema, JDBSelector* selector, GError** error)
 _error:
 	if (ret2)
 	{
-		while (j_db_internal_iterate(iterator->iterator, NULL, NULL))
+		while (j_db_internal_iterate(iterator, NULL))
 		{
 			/*do nothing*/
 		}
@@ -157,7 +157,7 @@ j_db_iterator_next (JDBIterator* iterator, GError** error)
 		j_bson_destroy(&iterator->bson);
 	}
 
-	if (G_UNLIKELY(!j_db_internal_iterate(iterator->iterator, &iterator->bson, error)))
+	if (G_UNLIKELY(!j_db_internal_iterate(iterator, error)))
 	{
 		goto _error;
 	}

--- a/lib/db/jdb-schema.c
+++ b/lib/db/jdb-schema.c
@@ -259,7 +259,6 @@ _error:
 		for (i = 0; i < count; i++)
 		{
 			g_free((*names)[i]);
-
 		}
 	}
 
@@ -420,7 +419,7 @@ j_db_schema_create (JDBSchema* schema, JBatch* batch, GError** error)
 
 	schema->server_side = TRUE;
 
-	if (G_UNLIKELY(!j_db_internal_schema_create(schema->namespace, schema->name, &schema->bson, batch, error)))
+	if (G_UNLIKELY(!j_db_internal_schema_create(schema, batch, error)))
 	{
 		goto _error;
 	}
@@ -445,7 +444,7 @@ j_db_schema_get (JDBSchema* schema, JBatch* batch, GError** error)
 	schema->server_side = TRUE;
 	schema->bson_initialized = TRUE;
 
-	if (G_UNLIKELY(!j_db_internal_schema_get(schema->namespace, schema->name, &schema->bson, batch, error)))
+	if (G_UNLIKELY(!j_db_internal_schema_get(schema, batch, error)))
 	{
 		goto _error;
 	}
@@ -465,7 +464,7 @@ j_db_schema_delete (JDBSchema* schema, JBatch* batch, GError** error)
 	g_return_val_if_fail(batch != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-	if (G_UNLIKELY(!j_db_internal_schema_delete(schema->namespace, schema->name, batch, error)))
+	if (G_UNLIKELY(!j_db_internal_schema_delete(schema, batch, error)))
 	{
 		goto _error;
 	}


### PR DESCRIPTION
Fix the refcounting error as described in #67. Fixes 3., and some cases of the error message in 2.

JDBSchema and others can now be allocated, applied to a batch, and immediately released within a loop before executing the batch.

GError still must not be allocated within a loop, because that makes no sense at all. If GError is supplied, then the user must provide a different GError for every network related call, to be able to process those errors independently later (after the call to j_batch_execute).
If the user don't want to know what failed, than the user should provide a NULL-ptr instead.
