### PR TITLE
changing the db-null-backend

### DIFF
--- a/backend/db/null.c
+++ b/backend/db/null.c
@@ -24,6 +24,17 @@
 
 #include <julea.h>
 
+G_LOCK_DEFINE_STATIC(global_lock);
+
+static
+bson_t* schema_cache = NULL;
+
+static
+bson_t* entry_cache = NULL;
+
+static
+guint entry_counter = 0;
+
 static
 gboolean
 backend_batch_start (gchar const* namespace, JSemantics* semantics, gpointer* batch, GError** error)
@@ -45,7 +56,6 @@ backend_batch_execute (gpointer batch, GError** error)
 
 	return TRUE;
 }
-
 static
 gboolean
 backend_schema_create (gpointer batch, gchar const* name, bson_t const* schema, GError** error)
@@ -54,6 +64,14 @@ backend_schema_create (gpointer batch, gchar const* name, bson_t const* schema, 
 	(void)batch;
 	(void)name;
 	(void)schema;
+
+	G_LOCK(global_lock);
+	if (schema_cache)
+	{
+		bson_destroy(schema_cache);
+	}
+	schema_cache = bson_copy(schema);
+	G_UNLOCK(global_lock);
 
 	return TRUE;
 }
@@ -67,7 +85,13 @@ backend_schema_get (gpointer batch, gchar const* name, bson_t* schema, GError** 
 	(void)name;
 	(void)schema;
 
-	return TRUE;
+	if (schema_cache)
+	{
+		bson_copy_to(schema_cache, schema);
+		return TRUE;
+	}
+
+	return FALSE;
 }
 
 static
@@ -77,6 +101,14 @@ backend_schema_delete (gpointer batch, gchar const* name, GError** error)
 	(void)error;
 	(void)batch;
 	(void)name;
+
+	G_LOCK(global_lock);
+	if (schema_cache)
+	{
+		bson_destroy(schema_cache);
+		schema_cache = NULL;
+	}
+	G_UNLOCK(global_lock);
 
 	return TRUE;
 }
@@ -90,6 +122,15 @@ backend_insert (gpointer batch, gchar const* name, bson_t const* metadata, bson_
 	(void)name;
 	(void)metadata;
 	(void)id;
+
+	G_LOCK(global_lock);
+	if (entry_cache)
+	{
+		bson_destroy(entry_cache);
+	}
+	entry_cache = bson_copy(metadata);
+	entry_counter++;
+	G_UNLOCK(global_lock);
 
 	return TRUE;
 }
@@ -116,6 +157,15 @@ backend_delete (gpointer batch, gchar const* name, bson_t const* selector, GErro
 	(void)name;
 	(void)selector;
 
+	G_LOCK(global_lock);
+	if (entry_cache)
+	{
+		bson_destroy(entry_cache);
+		entry_cache = NULL;
+	}
+	entry_counter--;
+	G_UNLOCK(global_lock);
+
 	return TRUE;
 }
 
@@ -123,22 +173,55 @@ static
 gboolean
 backend_query (gpointer batch, gchar const* name, bson_t const* selector, gpointer* iterator, GError** error)
 {
+	guint32* query_counter_local = *iterator = g_new(guint32, 1);
+
 	(void)error;
 	(void)batch;
 	(void)name;
 	(void)selector;
 	(void)iterator;
 
+	if (!entry_cache)
+	{
+		*query_counter_local = 0;
+	}
+	else if (selector)
+	{
+		*query_counter_local = 1;
+	}
+	else
+	{
+		*query_counter_local = entry_counter;
+	}
+
+	if (!*query_counter_local)
+	{
+		g_free(query_counter_local);
+		*iterator = NULL;
+		return FALSE;
+	}
+
 	return TRUE;
 }
-
 static
 gboolean
 backend_iterate (gpointer iterator, bson_t* metadata, GError** error)
 {
+	guint32* query_counter_local = iterator;
+
 	(void)error;
 	(void)iterator;
 	(void)metadata;
+
+	if ((*query_counter_local <= 0) || (!entry_cache))
+	{
+		g_free(iterator);
+		g_set_error_literal(error, J_BACKEND_DB_ERROR, J_BACKEND_DB_ERROR_ITERATOR_NO_MORE_ELEMENTS, "no more elements");
+		return FALSE;
+	}
+
+	(*query_counter_local)--;
+	bson_copy_to(entry_cache, metadata);
 
 	return TRUE;
 }


### PR DESCRIPTION
such that compareable benchmarks are possible.
Especially this ensures, that the client code behaves as usual, only the backend storage is 'null'